### PR TITLE
Check if the current OS is supported by md-babel

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { execFileSync } from "child_process";
 import { isInCodeBlock } from "./isInCodeBlock.js";
-import { handleNotSupportedOs, isOsSupported } from "./os.js";
+import { handleNotSupportedOS, isOSSupported } from "./os.js";
 import which from "which";
 
 /** 1-based line and column indices (conforming to cmark). */
@@ -31,8 +31,8 @@ export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
     "vscode-md-babel.executeBlockAtPoint",
     async () => {
-      if (!isOsSupported()) {
-        await handleNotSupportedOs(context);
+      if (!isOSSupported()) {
+        await handleNotSupportedOS(context);
         return;
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { execFileSync } from "child_process";
 import { isInCodeBlock } from "./isInCodeBlock.js";
+import { handleNotSupportedOs, isOsSupported } from "./os.js";
 
 /** 1-based line and column indices (conforming to cmark). */
 interface SourceLocation {
@@ -24,6 +25,11 @@ export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
     "vscode-md-babel.executeBlockAtPoint",
     async () => {
+      if (!isOsSupported()) {
+        await handleNotSupportedOs(context);
+        return;
+      }
+
       const editor = vscode.window.activeTextEditor;
       if (!editor) {
         vscode.window.showErrorMessage("No active editor!");

--- a/src/os.ts
+++ b/src/os.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+import { type } from "node:os";
+
+/**
+ * md-babel runs currently only on macOS and Linux.
+ * @returns whether md-babel runs on the current operating
+ * system
+ */
+export function isOsSupported(): boolean {
+  return ["Linux", "Darwin"].includes(type());
+}
+
+/**
+ * If the extension is activated for the first time and the
+ * OS is not supported by md-babel, that is it is not Linux
+ * or macOS, an error message is shown. To avoid showing the
+ * error message each time, it is stored in the global state
+ * that the extension was already activated.
+ *
+ * Otherwise, nothing happens.
+ *
+ * @param context the context of the extension
+ */
+export async function handleNotSupportedOs(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const alreadyActivated = "alreadyActivated";
+
+  if (context.globalState.get<boolean>(alreadyActivated)) {
+    return;
+  }
+
+  vscode.window.showErrorMessage(
+    "md-babel is currently only supported on Linux and macOS.",
+  );
+  await context.globalState.update(alreadyActivated, true);
+}

--- a/src/os.ts
+++ b/src/os.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { type } from "node:os";
+import { platform } from "node:os";
 
 /**
  * md-babel currently runs only on macOS and Linux.
@@ -7,7 +7,7 @@ import { type } from "node:os";
  * system
  */
 export function isOSSupported(): boolean {
-  return ["Linux", "Darwin"].includes(type());
+  return ["linux", "darwin"].includes(platform());
 }
 
 /**

--- a/src/os.ts
+++ b/src/os.ts
@@ -6,7 +6,7 @@ import { type } from "node:os";
  * @returns whether md-babel runs on the current operating
  * system
  */
-export function isOsSupported(): boolean {
+export function isOSSupported(): boolean {
   return ["Linux", "Darwin"].includes(type());
 }
 
@@ -21,7 +21,7 @@ export function isOsSupported(): boolean {
  *
  * @param context the context of the extension
  */
-export async function handleNotSupportedOs(
+export async function handleNotSupportedOS(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   const alreadyActivated = "alreadyActivated";

--- a/src/os.ts
+++ b/src/os.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { type } from "node:os";
 
 /**
- * md-babel runs currently only on macOS and Linux.
+ * md-babel currently runs only on macOS and Linux.
  * @returns whether md-babel runs on the current operating
  * system
  */


### PR DESCRIPTION
If the OS is supported, nothing happens.

If the OS is not supported, an error message is shown on the first activation of the extension. The error message tells the user that currently only Linux and macOS are supported by md-babel. Whether the extension was already activated once, is stored in the global state of the extension.

An OS is supported if [`os.type()`](https://nodejs.org/api/os.html#ostype) returns `'Linux'` or `'Darwin'`.