### PR TITLE
Add type for md-babel configuration

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,20 @@
+export interface Configuration {
+  evaluators: {
+    codeBlock: Record<string, CodeBlock>;
+  };
+}
+
+interface CodeBlock {
+  path: string;
+  defaultArguments: string[];
+  result: Result;
+}
+
+type Result = "codeBlock" | ImageResult;
+
+interface ImageResult {
+  type: "image";
+  extension: string;
+  directory: string;
+  filename: string;
+}

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -91,3 +91,25 @@ const hurl = {
     },
   },
 };
+
+const codeBlockWithImages: Configuration = {
+  evaluators: {
+    codeBlock: {
+      lang: {
+        path: "",
+        defaultArguments: [],
+        result: "codeBlock",
+      },
+      image: {
+        path: "",
+        defaultArguments: [],
+        result: {
+          type: "image",
+          extension: "",
+          directory: "",
+          filename: "",
+        },
+      },
+    },
+  },
+};

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -1,0 +1,93 @@
+import { Configuration } from "../configuration";
+
+// https://github.com/md-babel/md-babel-schema/blob/main/config/README.md#how-to-define-code-evaluator-backends
+const bashRubyPython: Configuration = {
+  evaluators: {
+    codeBlock: {
+      bash: {
+        path: "/usr/bin/env",
+        defaultArguments: ["bash"],
+        result: "codeBlock",
+      },
+      ruby: {
+        path: "/usr/bin/env",
+        defaultArguments: ["ruby"],
+        result: "codeBlock",
+      },
+      python: {
+        path: "/Users/YOUR_USER_NAME/.config/md-babel/python3env/bin/python3",
+        defaultArguments: [],
+        result: "codeBlock",
+      },
+    },
+  },
+};
+
+// https://github.com/md-babel/swift-markdown-babel/blob/main/Examples.md#emacs-lisp-evaluation
+const emacsLisp: Configuration = {
+  evaluators: {
+    codeBlock: {
+      elisp: {
+        path: "/usr/bin/env",
+        defaultArguments: ["emacsclient", "--eval"],
+        result: "codeBlock",
+      },
+    },
+  },
+};
+
+// https://github.com/md-babel/swift-markdown-babel/blob/main/Examples.md#mermaid-graph-rendering
+const mermaid: Configuration = {
+  evaluators: {
+    codeBlock: {
+      mermaid: {
+        path: "/path/to/mmdc",
+        defaultArguments: [
+          "--input",
+          "-",
+          "--outputFormat",
+          "svg",
+          "--output",
+          "-",
+        ],
+        result: {
+          type: "image",
+          extension: "svg",
+          directory: "./images/",
+          filename: "yyyyMMddHHmmss'--$fn__$hash'",
+        },
+      },
+    },
+  },
+};
+
+// https://github.com/md-babel/swift-markdown-babel/blob/main/Examples.md#plantuml-graph-rendering
+const plantUml: Configuration = {
+  evaluators: {
+    codeBlock: {
+      plantuml: {
+        path: "/path/to/plantuml",
+        defaultArguments: ["-pipe", "-noerror", "-tsvg"],
+        result: {
+          type: "image",
+          extension: "svg",
+          directory: "./images/",
+          filename: "yyyyMMddHHmmss'--$fn__$hash'",
+        },
+      },
+    },
+  },
+};
+
+// https://github.com/md-babel/swift-markdown-babel/blob/main/Examples.md#rest-api-testing-via-hurl
+const hurl = {
+  evaluators: {
+    codeBlock: {
+      hurl: {
+        path: "/path/to/hurl",
+        defaultArguments: [],
+        result: "codeBlock",
+      },
+    },
+  },
+};


### PR DESCRIPTION
The type describes the configuration file format for md-babel. The format is described in the md-babel-schema repository. For testing the type, I copied the examples from swift-markdown-babel.

After issue #18 is done, I will convert the examples to tests.

See also: https://github.com/md-babel/swift-markdown-babel/blob/main/Examples.md
See also: https://github.com/md-babel/md-babel-schema/blob/main/config/README.md
See also: https://www.totaltypescript.com/how-to-test-your-types
See also: https://github.com/md-babel/vscode-md-babel/issues/18