### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!-- DELETE THIS START -->
+
+The PR template tries to make reviewing PRs easier.
+
+Every PR should ideally help understand the problem it tries
+to solve. Of course, this depends on the size and complexity
+of the PR.
+
+The sections below are examples for this and can be omitted.
+
+If the PR is related to other issues or PRs, please
+reference them.
+
+For more information, see also
+https://github.com/md-babel/vscode-md-babel/issues/28.
+
+<!-- DELETE THIS END -->
+
+## What this PR does
+
+- which problem it solves
+- strategy/big picture plans, e.g.
+  https://github.com/md-babel/vscode-md-babel/pull/23
+- tactics involved to implement it
+- reasoning, with links to resources to get up to speed with
+  a topic
+
+## UI changes
+
+- add a screenshot with a short description
+
+## Dependencies
+
+- Which problem does the dependency solve?
+- short comparison with alternatives, if there are any


### PR DESCRIPTION
The PR template tries to guide contributors in writing understandable PR descriptions.

See also: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
Closes: https://github.com/md-babel/vscode-md-babel/issues/28