### PR TITLE
Add button with link to md-babel release page

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { execFileSync } from "child_process";
 import { isInCodeBlock } from "./isInCodeBlock.js";
 import { handleNotSupportedOS, isOSSupported } from "./os.js";
 import which from "which";
+import { isMdBabelInPath } from "./isMdBabelInPath.js";
 
 /** 1-based line and column indices (conforming to cmark). */
 interface SourceLocation {
@@ -55,24 +56,7 @@ export function activate(context: vscode.ExtensionContext) {
         config.get<string>("executablePath", defaultExecutablePath) ||
         which.sync("md-babel", { nothrow: true });
 
-      const releasePage = "Release Page";
-      if (mdBabelPath === null) {
-        vscode.window
-          .showErrorMessage(
-            `md-babel was not found. Please add md-babel to the path environment
-             variable ($PATH) or configure mdBabel.executablePath.
-             You can download md-babel from the release page.`,
-            releasePage,
-          )
-          .then((selection) => {
-            if (selection === releasePage) {
-              vscode.env.openExternal(
-                vscode.Uri.parse(
-                  "https://github.com/md-babel/swift-markdown-babel/releases/latest",
-                ),
-              );
-            }
-          });
+      if (!isMdBabelInPath(mdBabelPath)) {
         return;
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,11 +55,24 @@ export function activate(context: vscode.ExtensionContext) {
         config.get<string>("executablePath", defaultExecutablePath) ||
         which.sync("md-babel", { nothrow: true });
 
+      const releasePage = "Release Page";
       if (mdBabelPath === null) {
-        vscode.window.showErrorMessage(
-          `md-babel was not found. Please add md-babel to the path environment
-          variable ($PATH) or configure mdBabel.executablePath.`,
-        );
+        vscode.window
+          .showErrorMessage(
+            `md-babel was not found. Please add md-babel to the path environment
+             variable ($PATH) or configure mdBabel.executablePath.
+             You can download md-babel from the release page.`,
+            releasePage,
+          )
+          .then((selection) => {
+            if (selection === releasePage) {
+              vscode.env.openExternal(
+                vscode.Uri.parse(
+                  "https://github.com/md-babel/swift-markdown-babel/releases/latest",
+                ),
+              );
+            }
+          });
         return;
       }
 

--- a/src/isMdBabelInPath.ts
+++ b/src/isMdBabelInPath.ts
@@ -1,0 +1,28 @@
+import * as vscode from "vscode";
+
+export function isMdBabelInPath(
+  mdBabelPath: string | null,
+): mdBabelPath is string {
+  if (mdBabelPath === null) {
+    const releasePage = "Release Page";
+    vscode.window
+      .showErrorMessage(
+        `md-babel was not found. Please add md-babel to the path environment
+               variable ($PATH) or configure mdBabel.executablePath.
+               You can download md-babel from the release page.`,
+        releasePage,
+      )
+      .then((selection) => {
+        if (selection === releasePage) {
+          vscode.env.openExternal(
+            vscode.Uri.parse(
+              "https://github.com/md-babel/swift-markdown-babel/releases/latest",
+            ),
+          );
+        }
+      });
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
The PR adds a button with a link to the [latest release of md-babel](https://github.com/md-babel/swift-markdown-babel/releases/latest) and improves the error message in case `md-babel` is not found in `$PATH`. The button looks like this

<img width="484" alt="image" src="https://github.com/user-attachments/assets/77a6ccfc-c704-4a54-b442-838e3b9dd66f" />

I did not find a way to render Markdown or hyperlinks in `showErrorMessage`. Also, I am not sure if I have ever used an extension that did this. The examples for notifications in the UX guidelines also don't show such messages.

The links to the VS Code documentation are for `openExternal` and `showErrorMessage`.

See also: https://code.visualstudio.com/api/references/vscode-api#window
See also: https://code.visualstudio.com/api/ux-guidelines/notifications
See also: https://code.visualstudio.com/api/references/vscode-api#env
Related to: https://github.com/md-babel/vscode-md-babel/issues/14
